### PR TITLE
ci: bump sigstore/cosign-installer to v4.1.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -318,7 +318,7 @@ jobs:
 
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Sign image
         if: github.event_name != 'pull_request'


### PR DESCRIPTION
Bumps `sigstore/cosign-installer` from `v4.1.1` to `v4.1.2` (latest patch on the v4 line) in the image build-and-sign workflow.

Found during a workflow action-version audit; every other action in the repo is already on its latest major.