### PR TITLE
ci: sign update-badges commits via GraphQL createCommitOnBranch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -480,14 +480,32 @@ jobs:
           path: docs/badges/
           merge-multiple: true
 
-      - name: Commit badge updates
+      - name: Commit badge updates (signed via GraphQL)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add docs/badges/
-          if git diff --staged --quiet; then
+          set -euo pipefail
+          if git diff --quiet HEAD -- docs/badges/; then
             echo "No badge changes to commit"
-          else
-            git commit -m "ci: update security badges [skip ci]"
-            git push
+            exit 0
           fi
+          HEAD_OID=$(gh api "repos/${GITHUB_REPOSITORY}/branches/main" --jq .commit.sha)
+          additions=$(find docs/badges -type f -name '*.json' | sort | while read -r f; do
+            jq -n --arg path "$f" --arg contents "$(base64 -w0 < "$f")" \
+              '{path: $path, contents: $contents}'
+          done | jq -s .)
+          jq -n \
+            --arg repo "$GITHUB_REPOSITORY" \
+            --arg oid "$HEAD_OID" \
+            --argjson additions "$additions" \
+            '{
+              query: "mutation($input: CreateCommitOnBranchInput!) { createCommitOnBranch(input: $input) { commit { url oid } } }",
+              variables: {
+                input: {
+                  branch: { repositoryNameWithOwner: $repo, branchName: "main" },
+                  message: { headline: "ci: update security badges" },
+                  expectedHeadOid: $oid,
+                  fileChanges: { additions: $additions }
+                }
+              }
+            }' | gh api -X POST graphql --input -


### PR DESCRIPTION
## Why

The `required_signatures` rule on `main` (ruleset id 16777687, added 2026-05-23 as part of the GitHub org hardening chantier) rejects unsigned commits. The `update-badges` job in `build.yml` was using `git push` from the github-actions[bot] which produces unsigned commits, breaking the scheduled rebuild and any push to main that updates badges.

## What

Replace the `git commit + git push` block in the `update-badges` step with a `gh api graphql` call to the `createCommitOnBranch` mutation. Commits produced by this mutation are automatically signed by GitHub's web-flow key (`verified:true reason:valid`).

## Trade-offs

- No bypass actor needed on the ruleset; the signed-only invariant on main is preserved end-to-end.
- The `[skip ci]` marker is dropped from the commit message because it no longer prevents loops (the GraphQL commit doesn't re-trigger this same workflow on push since the workflow excludes itself via job conditions). Watch the first post-merge run to confirm.
- The added jq + base64 logic is inline (no new action dependency, no allowlist change required).

## Test plan

- [ ] Merge this PR
- [ ] Trigger `Scheduled Rebuild` manually via `gh workflow run scheduled-rebuild.yml`
- [ ] Verify the `update-badges` job pushes a commit successfully
- [ ] Verify the resulting commit shows `verified: true` via `gh api repos/getbrik/brik-images/commits/main --jq .commit.verification`