### PR TITLE
chore: add CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jeanjerome


### PR DESCRIPTION
Future-proofs review assignment when a 2nd maintainer joins. Solo for now (`* @jeanjerome`).

Part of S2.7 of the GitHub hardening chantier.