### PR TITLE
ci: enable Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,38 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "github-actions"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/images/analysis"
+      - "/images/base"
+      - "/images/deploy"
+      - "/images/dotnet"
+      - "/images/java"
+      - "/images/node"
+      - "/images/python"
+      - "/images/rust"
+      - "/images/scanner"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "08:00"
+      timezone: "Europe/Paris"
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: "build"
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
Enable Dependabot for weekly auto-update of GitHub Actions and (where applicable) Docker base images. Part of S2.2 of the GitHub hardening chantier.

Schedule: Mondays 08:00 Europe/Paris. Open-pull-requests-limit: 5 per ecosystem (10 for brik-images docker).