### PR TITLE
build(base): add glow for terminal-friendly markdown rendering

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,6 +133,7 @@ jobs:
           echo "jq_version=$(jq -r '.tools.jq' versions.json)" >> "$GITHUB_OUTPUT"
           echo "jv_version=$(jq -r '.tools.jv' versions.json)" >> "$GITHUB_OUTPUT"
           echo "docker_buildx_version=$(jq -r '.tools.docker_buildx' versions.json)" >> "$GITHUB_OUTPUT"
+          echo "glow_version=$(jq -r '.tools.glow' versions.json)" >> "$GITHUB_OUTPUT"
 
           # Read deploy_tools versions (used by deploy image)
           for key in $(jq -r '.deploy_tools | keys[]' versions.json); do
@@ -176,6 +177,7 @@ jobs:
           ARGS=""
           if [ "${{ matrix.stack }}" = "base" ]; then
             ARGS="JV_VERSION=${{ steps.versions.outputs.jv_version }}"
+            ARGS="${ARGS}\nGLOW_VERSION=${{ steps.versions.outputs.glow_version }}"
           elif [ "${{ matrix.stack }}" = "analysis" ]; then
             ARGS="SEMGREP_VERSION=${{ steps.versions.outputs.semgrep_version }}"
             ARGS="${ARGS}\nCHECKOV_VERSION=${{ steps.versions.outputs.checkov_version }}"

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -25,11 +25,11 @@ RUN apk add --no-cache git \
 # ---------------------------------------------------------------------------
 FROM alpine:${VERSION}
 
-ARG VERSION
 ARG YQ_VERSION
 ARG JQ_VERSION
 ARG JV_VERSION
 ARG DOCKER_BUILDX_VERSION
+ARG GLOW_VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/getbrik/brik-images"
 LABEL org.opencontainers.image.title="brik-runner-base"
@@ -37,13 +37,25 @@ LABEL org.opencontainers.image.description="Brik CI runner base image with bash,
 LABEL org.opencontainers.image.vendor="getbrik"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# glow lives in Alpine's community repo (since v3.20). The official
-# alpine:${VERSION} image only enables main, so we add community via
-# --repository for this single install. The URL tracks the same Alpine
-# version as the base image to keep the package set consistent.
-RUN apk add --no-cache \
-    --repository=https://dl-cdn.alpinelinux.org/alpine/v${VERSION}/community \
-    bash git curl ca-certificates glow
+RUN apk add --no-cache bash git curl ca-certificates
+
+# glow is not packaged in Alpine main/community (only edge/testing,
+# which is too volatile for a pinned base image). Install the upstream
+# GitHub release tarball instead. The version is pinned via build-arg
+# fed from versions.json (.tools.glow). curl + tar are split so a
+# curl HTTP failure surfaces immediately (no piping into tar, which
+# would silently succeed on truncated input).
+RUN GLOW_VER="${GLOW_VERSION#v}" \
+ && ARCH=$(uname -m) \
+ && case "$ARCH" in \
+        x86_64)  GARCH="x86_64" ;; \
+        aarch64) GARCH="arm64"  ;; \
+        *)       echo "unsupported arch: $ARCH" >&2; exit 1 ;; \
+    esac \
+ && curl -fsSL -o /tmp/glow.tar.gz "https://github.com/charmbracelet/glow/releases/download/v${GLOW_VER}/glow_${GLOW_VER}_Linux_${GARCH}.tar.gz" \
+ && tar -xzf /tmp/glow.tar.gz -C /tmp \
+ && install -m 0755 "/tmp/glow_${GLOW_VER}_Linux_${GARCH}/glow" /usr/local/bin/glow \
+ && rm -rf "/tmp/glow.tar.gz" "/tmp/glow_${GLOW_VER}_Linux_${GARCH}"
 
 ENV YQ_VERSION=${YQ_VERSION} \
     JQ_VERSION=${JQ_VERSION} \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -25,6 +25,7 @@ RUN apk add --no-cache git \
 # ---------------------------------------------------------------------------
 FROM alpine:${VERSION}
 
+ARG VERSION
 ARG YQ_VERSION
 ARG JQ_VERSION
 ARG JV_VERSION
@@ -36,7 +37,13 @@ LABEL org.opencontainers.image.description="Brik CI runner base image with bash,
 LABEL org.opencontainers.image.vendor="getbrik"
 LABEL org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache bash git curl ca-certificates glow
+# glow lives in Alpine's community repo (since v3.20). The official
+# alpine:${VERSION} image only enables main, so we add community via
+# --repository for this single install. The URL tracks the same Alpine
+# version as the base image to keep the package set consistent.
+RUN apk add --no-cache \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v${VERSION}/community \
+    bash git curl ca-certificates glow
 
 ENV YQ_VERSION=${YQ_VERSION} \
     JQ_VERSION=${JQ_VERSION} \

--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -32,11 +32,11 @@ ARG DOCKER_BUILDX_VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/getbrik/brik-images"
 LABEL org.opencontainers.image.title="brik-runner-base"
-LABEL org.opencontainers.image.description="Brik CI runner base image with bash, yq, jq, jv, git"
+LABEL org.opencontainers.image.description="Brik CI runner base image with bash, yq, jq, jv, git, glow"
 LABEL org.opencontainers.image.vendor="getbrik"
 LABEL org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache bash git curl ca-certificates
+RUN apk add --no-cache bash git curl ca-certificates glow
 
 ENV YQ_VERSION=${YQ_VERSION} \
     JQ_VERSION=${JQ_VERSION} \
@@ -53,4 +53,4 @@ COPY --from=jv-builder /jv /usr/local/bin/jv
 RUN echo "brik-runner" > /.brik-runner
 
 # Verify prerequisites
-RUN yq --version && jq --version && jv --version && git --version && bash --version
+RUN yq --version && jq --version && jv --version && git --version && bash --version && glow --version

--- a/versions.json
+++ b/versions.json
@@ -4,7 +4,8 @@
     "yq": "v4.53.2",
     "jq": "1.8.1",
     "jv": "v0.7.0",
-    "docker_buildx": "v0.34.1"
+    "docker_buildx": "v0.34.1",
+    "glow": "v2.1.2"
   },
   "deploy_tools": {
     "helm": "v4.2.0",


### PR DESCRIPTION
## Why

brik's notify stage dumps `aggregate-report.md` to CI job logs. Without a renderer the markdown source is unreadable. This adds `glow` (charmbracelet, Alpine `community` repo package) to brik-runner-base so notify can render the report with ANSI colors, box drawings and emoji.

## Pairing

Companion PR on the brik repo updates `lib/stages/notify.sh` to use glow when available, with graceful fallback to `cat` for older runners or local mode without glow installed.

## Impact

- Image size: +12 MB on brik-runner-base
- Used by: notify stage on Jenkins (`runInBase('notify')`), GitLab (via the upcoming `BRIK_BASE_IMAGE` variable in brik's pipeline.yml), local mode (graceful degradation)
