### PR TITLE
fix(security): address x/crypto and x/net critical CVEs

### DIFF
--- a/.grype.yaml
+++ b/.grype.yaml
@@ -27,3 +27,22 @@ ignore:
   # yq v4.52.5 was also affected and has been bumped to v4.53.2 which
   # ships a patched Go (no longer needs an ignore once images rebuild).
   - vulnerability: CVE-2026-27143
+
+  # golang.org/x/crypto < 0.52.0 (ssh, ssh/agent): key-constraint and
+  # permission-enforcement bypasses. Statically linked into docker-buildx
+  # v0.34.1 (latest, ships x/crypto v0.50.0). No patched buildx release
+  # exists yet -- remove these once upstream rebuilds with x/crypto >= 0.52.0.
+  - vulnerability: CVE-2026-39830   # GO-2026-5017
+  - vulnerability: CVE-2026-39831   # GO-2026-5019
+  - vulnerability: CVE-2026-39832   # GO-2026-5006
+  - vulnerability: CVE-2026-39833   # GO-2026-5005
+  - vulnerability: CVE-2026-39834   # GO-2026-5020
+  - vulnerability: CVE-2026-42508   # GO-2026-5021
+  - vulnerability: CVE-2026-46595   # GO-2026-5023
+
+  # golang.org/x/net < 0.55.0 (idna): failure to reject ASCII-only
+  # Punycode-encoded labels. Statically linked into docker-buildx v0.34.1
+  # (x/net v0.53.0) and glow v2.1.2 (x/net v0.40.0) -- both latest, no
+  # patched release. yq is fixed by the v4.53.3 bump and needs no ignore.
+  # Remove once buildx and glow rebuild with x/net >= 0.55.0.
+  - vulnerability: CVE-2026-39821   # GO-2026-5026

--- a/versions.json
+++ b/versions.json
@@ -1,7 +1,7 @@
 {
   "registry": "ghcr.io/getbrik",
   "tools": {
-    "yq": "v4.53.2",
+    "yq": "v4.53.3",
     "jq": "1.8.1",
     "jv": "v0.7.0",
     "docker_buildx": "v0.34.1",


### PR DESCRIPTION
## Context

The first `main` build to complete the Grype gate after today's vuln-DB update failed across **every** image. Root cause is a batch of newly-disclosed 2026 Critical advisories in Go modules statically linked into the third-party binaries we install (`docker-buildx`, `yq`, `glow`) -- not a regression from any recent change. Grype runs only on `main` (`event_name != pull_request`), so PR CI never surfaced it.

## CVEs

| Module | Fixed in | Binaries | CVEs |
|--------|----------|----------|------|
| `golang.org/x/crypto` | 0.52.0 | docker-buildx (v0.50.0) | 39830, 39831, 39832, 39833, 39834, 42508, 46595 |
| `golang.org/x/net` | 0.55.0 | yq (v0.52.0), glow (v0.40.0), docker-buildx (v0.53.0) | 39821 |
| python interpreter | n/a here | python:3.13-slim | CVE-2026-7210 (tracked separately; floats with the base tag) |

## Changes

- **`versions.json`**: `yq` v4.53.2 -> **v4.53.3** (ships `x/net` v0.55.0 -> clears CVE-2026-39821 in yq, no suppression needed).
- **`.grype.yaml`**: suppress the x/crypto cluster (buildx) and x/net (buildx + glow) with per-CVE tracking comments, following the existing convention. `docker-buildx` v0.34.1 and `glow` v2.1.2 are both the latest upstream release; no patched build exists yet. Entries are scoped for removal once upstream rebuilds.

## Why suppress buildx/glow rather than bump

Both are already on their newest release (predating the advisories). There is no version to bump to. The repo's established pattern (`.grype.yaml` + `scripts/review-cve-suppressions.sh` + weekly `cve-review.yml`) is exactly for upstream Go binaries we cannot fix until they rebuild.

## Test plan

- [x] `versions.json` valid JSON; yq bump propagates through `generate-bake.sh` (13 targets)
- [x] `.grype.yaml` valid YAML (11 ignore entries)
- [ ] Post-merge `main` Grype gate green (the real proof -- runs only on main)
- [ ] `cve-review.yml` weekly job reconciles the new entries against upstream releases