### PR TITLE
fix(security): sync .cve-suppressions.json with .grype.yaml

### DIFF
--- a/.cve-suppressions.json
+++ b/.cve-suppressions.json
@@ -51,6 +51,291 @@
           "pinned_in": ".security_tools.dockle"
         }
       ]
+    },
+    {
+      "cve": "CVE-2026-39830",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39830",
+      "rationale": "golang.org/x/crypto < 0.52.0 (ssh / ssh-agent key-constraint and permission-enforcement bypass), statically linked into the listed Go binaries. Suppressed in .grype.yaml under its GO-2026-* id (Grype keys go-module matches by GO id). Remove once each tool ships a release built with x/crypto >= 0.52.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "gitleaks",
+          "repo": "gitleaks/gitleaks",
+          "pinned_in": ".security_tools.gitleaks"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-39831",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39831",
+      "rationale": "golang.org/x/crypto < 0.52.0 (ssh / ssh-agent key-constraint and permission-enforcement bypass), statically linked into the listed Go binaries. Suppressed in .grype.yaml under its GO-2026-* id (Grype keys go-module matches by GO id). Remove once each tool ships a release built with x/crypto >= 0.52.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "gitleaks",
+          "repo": "gitleaks/gitleaks",
+          "pinned_in": ".security_tools.gitleaks"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-39832",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39832",
+      "rationale": "golang.org/x/crypto < 0.52.0 (ssh / ssh-agent key-constraint and permission-enforcement bypass), statically linked into the listed Go binaries. Suppressed in .grype.yaml under its GO-2026-* id (Grype keys go-module matches by GO id). Remove once each tool ships a release built with x/crypto >= 0.52.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "gitleaks",
+          "repo": "gitleaks/gitleaks",
+          "pinned_in": ".security_tools.gitleaks"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-39833",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39833",
+      "rationale": "golang.org/x/crypto < 0.52.0 (ssh / ssh-agent key-constraint and permission-enforcement bypass), statically linked into the listed Go binaries. Suppressed in .grype.yaml under its GO-2026-* id (Grype keys go-module matches by GO id). Remove once each tool ships a release built with x/crypto >= 0.52.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "gitleaks",
+          "repo": "gitleaks/gitleaks",
+          "pinned_in": ".security_tools.gitleaks"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-39834",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39834",
+      "rationale": "golang.org/x/crypto < 0.52.0 (ssh / ssh-agent key-constraint and permission-enforcement bypass), statically linked into the listed Go binaries. Suppressed in .grype.yaml under its GO-2026-* id (Grype keys go-module matches by GO id). Remove once each tool ships a release built with x/crypto >= 0.52.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "gitleaks",
+          "repo": "gitleaks/gitleaks",
+          "pinned_in": ".security_tools.gitleaks"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-42508",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-42508",
+      "rationale": "golang.org/x/crypto < 0.52.0 (ssh / ssh-agent key-constraint and permission-enforcement bypass), statically linked into the listed Go binaries. Suppressed in .grype.yaml under its GO-2026-* id (Grype keys go-module matches by GO id). Remove once each tool ships a release built with x/crypto >= 0.52.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "gitleaks",
+          "repo": "gitleaks/gitleaks",
+          "pinned_in": ".security_tools.gitleaks"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-46595",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-46595",
+      "rationale": "golang.org/x/crypto < 0.52.0 (ssh / ssh-agent key-constraint and permission-enforcement bypass), statically linked into the listed Go binaries. Suppressed in .grype.yaml under its GO-2026-* id (Grype keys go-module matches by GO id). Remove once each tool ships a release built with x/crypto >= 0.52.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "gitleaks",
+          "repo": "gitleaks/gitleaks",
+          "pinned_in": ".security_tools.gitleaks"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-39821",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-39821",
+      "rationale": "golang.org/x/net < 0.55.0 (idna: ASCII-only Punycode label not rejected), statically linked into the listed Go binaries. Suppressed in .grype.yaml as GO-2026-5026. yq was also affected and is fixed by the v4.53.3 bump (no longer suppressed). Remove the rest once each tool ships a release built with x/net >= 0.55.0.",
+      "tools": [
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        },
+        {
+          "name": "glow",
+          "repo": "charmbracelet/glow",
+          "pinned_in": ".tools.glow"
+        },
+        {
+          "name": "grype",
+          "repo": "anchore/grype",
+          "pinned_in": ".security_tools.grype"
+        },
+        {
+          "name": "syft",
+          "repo": "anchore/syft",
+          "pinned_in": ".security_tools.syft"
+        },
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-33747",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-33747",
+      "rationale": "github.com/moby/buildkit < 0.28.1 (malicious frontend file escape), statically linked into osv-scanner (and bundled by docker-buildx). Suppressed in .grype.yaml as GO-2026-4858. Remove once upstream ships a release built with buildkit >= 0.28.1.",
+      "tools": [
+        {
+          "name": "osv-scanner",
+          "repo": "google/osv-scanner",
+          "pinned_in": ".security_tools.osv_scanner"
+        },
+        {
+          "name": "docker-buildx",
+          "repo": "docker/buildx",
+          "pinned_in": ".tools.docker_buildx"
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2026-7210",
+      "url": "https://nvd.nist.gov/vuln/detail/CVE-2026-7210",
+      "rationale": "CPython Expat hash-flooding in xml.parsers.expat / xml.etree.ElementTree (DoS). Affects the python:3.13 and python:3.14 slim base images; only fixed in 3.15.0b2, with no stable 3.13.x/3.14.x backport to rebase onto yet. NOTE: tracked against the python stack versions (floats with the base image tag), not a pinned GitHub-release tool -- the status column is advisory only. Remove once a stable Python point release backports the fix.",
+      "tools": [
+        {
+          "name": "cpython",
+          "repo": "python/cpython",
+          "pinned_in": ".stacks.python.versions | join(\"/\")"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Why

The weekly `cve-review` job (`scripts/review-cve-suppressions.sh` + `.github/workflows/cve-review.yml`) reads **`.cve-suppressions.json`**, a structured manifest that must stay in lockstep with `.grype.yaml`. PRs #21/#22 added grype ignores but did not mirror them here, so the weekly report kept tracking only the 3 original CVEs -- nobody would be nudged to drop the new ignores once buildx/glow/etc. rebuild.

There is **no automated drift-check** between the two files, which is exactly why this diverged silently (see below).

## Changes

Add structured metadata for the genuinely-new suppressions, with the affected pinned tools resolved from the actual carriers reported by code-scanning (these CVEs span the whole scanner toolchain, not just buildx/glow):

| CVE(s) | Affected pinned tools |
|--------|-----------------------|
| x/crypto cluster (7) + x/net (CVE-2026-39821) | docker-buildx, glow, grype, syft, osv-scanner, gitleaks |
| moby/buildkit CVE-2026-33747 | osv-scanner, docker-buildx |
| CPython CVE-2026-7210 | python stack (advisory-only row) |

The two stdlib GO-id ignores (`GO-2025-3563` / `GO-2026-4337`) map to the already-tracked `CVE-2025-22871` / `CVE-2025-68121` entries (dockle/gitleaks) -- no new metadata needed.

## Validation

`./scripts/review-cve-suppressions.sh` runs clean and now emits all 13 sections. Statuses compute correctly: `docker-buildx`/`osv-scanner` STILL_BLOCKED (already latest), `grype` (0.112.0 -> v0.114.0) and `syft` (1.44.0 -> v1.45.1) BUMP_AVAILABLE.

## Follow-up (not in this PR)

Recommend a CI drift-guard so `.grype.yaml` and `.cve-suppressions.json` can never silently diverge again. See PR discussion.