### PR TITLE
ci(security): guard .grype.yaml / .cve-suppressions.json lockstep

### DIFF
--- a/.cve-suppressions.json
+++ b/.cve-suppressions.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "Structured metadata for every CVE suppressed in .grype.yaml. Consumed by scripts/review-cve-suppressions.sh and the weekly cve-review workflow. Each entry MUST stay in lockstep with .grype.yaml -- if you add or remove a suppression there, mirror the change here. The pinned_in field is a jq path into versions.json so the script can fetch the currently-pinned version automatically.",
+  "$comment": "Structured metadata for every CVE suppressed in .grype.yaml. Consumed by scripts/review-cve-suppressions.sh and the weekly cve-review workflow. Each entry MUST stay in lockstep with .grype.yaml -- this is enforced in CI by scripts/check-cve-suppressions-sync.sh, which compares the union of every entry grype_ids[] against the vulnerability ids in .grype.yaml. grype_ids holds the exact id(s) Grype keys the match by (a GO-YYYY-NNNN id for go-module/stdlib matches, the CVE for OS/interpreter packages). The pinned_in field is a jq path into versions.json so the script can fetch the currently-pinned version automatically.",
   "suppressions": [
     {
       "cve": "CVE-2025-22871",
@@ -11,6 +11,10 @@
           "repo": "goodwithtech/dockle",
           "pinned_in": ".security_tools.dockle"
         }
+      ],
+      "grype_ids": [
+        "CVE-2025-22871",
+        "GO-2025-3563"
       ]
     },
     {
@@ -28,6 +32,10 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "CVE-2025-68121",
+        "GO-2026-4337"
       ]
     },
     {
@@ -50,6 +58,9 @@
           "repo": "goodwithtech/dockle",
           "pinned_in": ".security_tools.dockle"
         }
+      ],
+      "grype_ids": [
+        "CVE-2026-27143"
       ]
     },
     {
@@ -82,6 +93,9 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5017"
       ]
     },
     {
@@ -114,6 +128,9 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5019"
       ]
     },
     {
@@ -146,6 +163,9 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5006"
       ]
     },
     {
@@ -178,6 +198,9 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5005"
       ]
     },
     {
@@ -210,6 +233,9 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5020"
       ]
     },
     {
@@ -242,6 +268,9 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5021"
       ]
     },
     {
@@ -274,6 +303,9 @@
           "repo": "gitleaks/gitleaks",
           "pinned_in": ".security_tools.gitleaks"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5023"
       ]
     },
     {
@@ -306,6 +338,9 @@
           "repo": "google/osv-scanner",
           "pinned_in": ".security_tools.osv_scanner"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-5026"
       ]
     },
     {
@@ -323,6 +358,9 @@
           "repo": "docker/buildx",
           "pinned_in": ".tools.docker_buildx"
         }
+      ],
+      "grype_ids": [
+        "GO-2026-4858"
       ]
     },
     {
@@ -335,6 +373,9 @@
           "repo": "python/cpython",
           "pinned_in": ".stacks.python.versions | join(\"/\")"
         }
+      ],
+      "grype_ids": [
+        "CVE-2026-7210"
       ]
     }
   ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,6 +60,14 @@ jobs:
         with:
           dockerfile: images/deploy/Dockerfile
 
+  cve-suppressions-sync:
+    name: CVE suppressions in sync
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+      - name: Check .grype.yaml and .cve-suppressions.json are in lockstep
+        run: ./scripts/check-cve-suppressions-sync.sh
+
   generate-matrix:
     name: Generate Build Matrix
     runs-on: ubuntu-latest

--- a/scripts/check-cve-suppressions-sync.sh
+++ b/scripts/check-cve-suppressions-sync.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# check-cve-suppressions-sync.sh - Enforce that .grype.yaml and
+# .cve-suppressions.json stay in lockstep.
+#
+# .grype.yaml holds the ignore rules that gate the build; .cve-suppressions.json
+# holds the structured metadata the weekly cve-review job reports from. The two
+# can silently diverge (adding an ignore without mirroring its metadata), which
+# is exactly how the review report goes stale. This check fails when the set of
+# `vulnerability:` ids in .grype.yaml differs from the union of every entry's
+# `grype_ids` in .cve-suppressions.json.
+#
+# Exit: 0 when in sync, 1 on drift or malformed input. Intended for CI.
+#
+# Requires: bash, jq.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+GRYPE_FILE="${ROOT_DIR}/.grype.yaml"
+SUPPRESSIONS_FILE="${ROOT_DIR}/.cve-suppressions.json"
+
+require() {
+    command -v "$1" >/dev/null 2>&1 || { printf 'ERROR: %s is required\n' "$1" >&2; exit 1; }
+}
+require jq
+
+[[ -f "$GRYPE_FILE" ]] || { printf 'ERROR: %s not found\n' "$GRYPE_FILE" >&2; exit 1; }
+[[ -f "$SUPPRESSIONS_FILE" ]] || { printf 'ERROR: %s not found\n' "$SUPPRESSIONS_FILE" >&2; exit 1; }
+
+# Ignore ids declared in the grype gate config. Strips the leading
+# "- vulnerability:" and any trailing "# comment", keeping the bare id.
+grype_ids="$(
+    grep -E '^[[:space:]]*-[[:space:]]*vulnerability:' "$GRYPE_FILE" \
+        | sed -E 's/^[[:space:]]*-[[:space:]]*vulnerability:[[:space:]]*//; s/[[:space:]]*#.*$//; s/[[:space:]]*$//' \
+        | sort -u
+)"
+
+# Ids covered by the structured metadata (union of every entry's grype_ids[]).
+# Fail loudly if any entry is missing grype_ids rather than silently undercount.
+missing_meta="$(jq -r '.suppressions[] | select((.grype_ids // []) | length == 0) | .cve' "$SUPPRESSIONS_FILE")"
+if [[ -n "$missing_meta" ]]; then
+    printf 'ERROR: .cve-suppressions.json entries missing a grype_ids field:\n' >&2
+    printf '  %s\n' $missing_meta >&2
+    exit 1
+fi
+
+json_ids="$(jq -r '.suppressions[].grype_ids[]' "$SUPPRESSIONS_FILE" | sort -u)"
+
+only_grype="$(comm -23 <(printf '%s\n' "$grype_ids") <(printf '%s\n' "$json_ids"))"
+only_json="$(comm -13 <(printf '%s\n' "$grype_ids") <(printf '%s\n' "$json_ids"))"
+
+if [[ -n "$only_grype" || -n "$only_json" ]]; then
+    printf 'ERROR: .grype.yaml and .cve-suppressions.json are out of sync.\n' >&2
+    [[ -n "$only_grype" ]] && {
+        printf '\n  In .grype.yaml but not mirrored in .cve-suppressions.json (add metadata):\n' >&2
+        printf '    %s\n' $only_grype >&2
+    }
+    [[ -n "$only_json" ]] && {
+        printf '\n  In .cve-suppressions.json grype_ids but not in .grype.yaml (stale, remove):\n' >&2
+        printf '    %s\n' $only_json >&2
+    }
+    exit 1
+fi
+
+printf 'OK: .grype.yaml and .cve-suppressions.json are in sync (%s ids).\n' \
+    "$(printf '%s\n' "$grype_ids" | grep -c .)"


### PR DESCRIPTION
## Why

`.grype.yaml` (gates the build) and `.cve-suppressions.json` (feeds the weekly cve-review report) are coupled only by a comment that says "keep in lockstep". Nothing enforced it, so they diverged silently this week -- #21/#22 added grype ignores, #23 had to retro-fit the metadata. This adds the missing guard.

## What

- **`scripts/check-cve-suppressions-sync.sh`**: fails when the set of `vulnerability:` ids in `.grype.yaml` differs from the union of every entry's `grype_ids[]` in `.cve-suppressions.json`. Reports both directions (missing metadata / stale entry).
- **`.cve-suppressions.json`**: each entry gains a `grype_ids` field recording the exact id Grype keys the match by -- `GO-YYYY-NNNN` for go-module/stdlib matches, the CVE for OS/interpreter packages. (This is the crux of the earlier failure: Grype keys go-module vulns by GO id, not CVE.)
- **`build.yml`**: new fast `cve-suppressions-sync` job runs the check on every push/PR (and via the scheduled reusable-workflow call).

## Validation

- `shellcheck --severity=warning` clean; `bash -n` ok
- In-sync -> `OK ... (15 ids)`, exit 0
- Drift injected (un-mirrored ignore) -> exit 1, names the missing id
- Stale json id (in metadata, not in .grype.yaml) -> exit 1, names the stale id
- `build.yml` parses; new job shows as "CVE suppressions in sync"

## Effect

From now on, adding a grype ignore without mirroring its review metadata (or vice-versa) fails CI instead of silently staling the weekly report.