### PR TITLE
feat(images): add cosign and oras to scanner and deploy runners

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -411,6 +411,12 @@ jobs:
             value=$(jq -r ".deploy_tools.\"${key}\"" versions.json)
             echo "${key}_version=${value}" >> "$GITHUB_OUTPUT"
           done
+          # Evidence tools (cosign, oras): the deploy image verifies the signed
+          # attestation on the resolved digest before deploying.
+          for key in $(jq -r '.evidence_tools | keys[]' versions.json); do
+            value=$(jq -r ".evidence_tools.\"${key}\"" versions.json)
+            echo "${key}_version=${value}" >> "$GITHUB_OUTPUT"
+          done
 
           first=$(jq -r ".stacks.\"${{ matrix.stack }}\".versions[0]" versions.json)
           if [ "$first" = "${{ matrix.version }}" ]; then
@@ -449,6 +455,8 @@ jobs:
             HELM_VERSION=${{ steps.versions.outputs.helm_version }}
             KUBECTL_VERSION=${{ steps.versions.outputs.kubectl_version }}
             ARGOCD_VERSION=${{ steps.versions.outputs.argocd_version }}
+            COSIGN_VERSION=${{ steps.versions.outputs.cosign_version }}
+            ORAS_VERSION=${{ steps.versions.outputs.oras_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -465,6 +473,8 @@ jobs:
             HELM_VERSION=${{ steps.versions.outputs.helm_version }}
             KUBECTL_VERSION=${{ steps.versions.outputs.kubectl_version }}
             ARGOCD_VERSION=${{ steps.versions.outputs.argocd_version }}
+            COSIGN_VERSION=${{ steps.versions.outputs.cosign_version }}
+            ORAS_VERSION=${{ steps.versions.outputs.oras_version }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,12 @@ jobs:
             echo "${key}_version=${value}" >> "$GITHUB_OUTPUT"
           done
 
+          # Read evidence_tools versions (cosign, oras: scanner signs, deploy verifies)
+          for key in $(jq -r '.evidence_tools | keys[]' versions.json); do
+            value=$(jq -r ".evidence_tools.\"${key}\"" versions.json)
+            echo "${key}_version=${value}" >> "$GITHUB_OUTPUT"
+          done
+
           # Check if this version is first in the array (gets "latest" tag)
           first=$(jq -r ".stacks.\"${{ matrix.stack }}\".versions[0]" versions.json)
           if [ "$first" = "${{ matrix.version }}" ]; then
@@ -195,6 +201,8 @@ jobs:
             ARGS="HELM_VERSION=${{ steps.versions.outputs.helm_version }}"
             ARGS="${ARGS}\nKUBECTL_VERSION=${{ steps.versions.outputs.kubectl_version }}"
             ARGS="${ARGS}\nARGOCD_VERSION=${{ steps.versions.outputs.argocd_version }}"
+            ARGS="${ARGS}\nCOSIGN_VERSION=${{ steps.versions.outputs.cosign_version }}"
+            ARGS="${ARGS}\nORAS_VERSION=${{ steps.versions.outputs.oras_version }}"
           elif [ "${{ matrix.stack }}" = "scanner" ]; then
             ARGS="GRYPE_VERSION=${{ steps.versions.outputs.grype_version }}"
             ARGS="${ARGS}\nSYFT_VERSION=${{ steps.versions.outputs.syft_version }}"
@@ -204,6 +212,8 @@ jobs:
             ARGS="${ARGS}\nTRUFFLEHOG_VERSION=${{ steps.versions.outputs.trufflehog_version }}"
             ARGS="${ARGS}\nDOCKLE_VERSION=${{ steps.versions.outputs.dockle_version }}"
             ARGS="${ARGS}\nCYCLONEDX_CLI_VERSION=${{ steps.versions.outputs.cyclonedx_cli_version }}"
+            ARGS="${ARGS}\nCOSIGN_VERSION=${{ steps.versions.outputs.cosign_version }}"
+            ARGS="${ARGS}\nORAS_VERSION=${{ steps.versions.outputs.oras_version }}"
           fi
           # Use multiline output
           {

--- a/images/deploy/Dockerfile
+++ b/images/deploy/Dockerfile
@@ -1,15 +1,17 @@
 # brik-runner-deploy - Deploy tools for Brik CI/CD pipelines
-# Includes: docker compose, ssh, rsync, helm, kubectl, argocd CLI
+# Includes: docker compose, ssh, rsync, helm, kubectl, argocd CLI, cosign, oras
 # hadolint ignore=DL3007
 FROM ghcr.io/getbrik/brik-runner-base:latest
 
 ARG HELM_VERSION
 ARG KUBECTL_VERSION
 ARG ARGOCD_VERSION
+ARG COSIGN_VERSION
+ARG ORAS_VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/getbrik/brik-images"
 LABEL org.opencontainers.image.title="brik-runner-deploy"
-LABEL org.opencontainers.image.description="Brik CI runner with deploy tools (compose, ssh, rsync, helm, kubectl, argocd)"
+LABEL org.opencontainers.image.description="Brik CI runner with deploy tools (compose, ssh, rsync, helm, kubectl, argocd, cosign, oras)"
 LABEL org.opencontainers.image.vendor="getbrik"
 LABEL org.opencontainers.image.licenses="MIT"
 
@@ -38,6 +40,14 @@ RUN ARCH="$(uname -m)" \
        "https://github.com/argoproj/argo-cd/releases/download/${ARGOCD_VERSION}/argocd-linux-${ARCH_GO}" \
     && chmod +x /usr/local/bin/argocd
 
+# Evidence tools (cosign, oras): verify the image signature/attestation before
+# deploying (fail-closed CD preflight) and read the referrer graph.
+ENV COSIGN_VERSION=${COSIGN_VERSION} \
+    ORAS_VERSION=${ORAS_VERSION}
+
+COPY scripts/install-evidence-tools.sh /tmp/install-evidence-tools.sh
+RUN chmod +x /tmp/install-evidence-tools.sh && /tmp/install-evidence-tools.sh && rm /tmp/install-evidence-tools.sh
+
 # Verify all deploy tools
 # hadolint ignore=DL3001
 RUN docker compose version \
@@ -45,4 +55,6 @@ RUN docker compose version \
     && rsync --version \
     && helm version --short \
     && kubectl version --client \
-    && argocd version --client
+    && argocd version --client \
+    && cosign version \
+    && oras version

--- a/images/scanner/Dockerfile
+++ b/images/scanner/Dockerfile
@@ -1,5 +1,6 @@
 # brik-runner-scanner - Security scanning tools (static Go binaries)
-# Contains: grype, syft, osv-scanner, hadolint, gitleaks, trufflehog, dockle
+# Contains: grype, syft, osv-scanner, hadolint, gitleaks, trufflehog, dockle,
+#           cyclonedx-cli, cosign, oras
 ARG VERSION
 FROM alpine:3.23
 
@@ -13,11 +14,13 @@ ARG GITLEAKS_VERSION
 ARG TRUFFLEHOG_VERSION
 ARG DOCKLE_VERSION
 ARG CYCLONEDX_CLI_VERSION
+ARG COSIGN_VERSION
+ARG ORAS_VERSION
 ARG DOCKER_BUILDX_VERSION
 
 LABEL org.opencontainers.image.source="https://github.com/getbrik/brik-images"
 LABEL org.opencontainers.image.title="brik-runner-scanner"
-LABEL org.opencontainers.image.description="Brik CI runner with scanning tools (grype, syft, osv-scanner, hadolint, gitleaks, trufflehog, dockle, cyclonedx-cli)"
+LABEL org.opencontainers.image.description="Brik CI runner with scanning tools (grype, syft, osv-scanner, hadolint, gitleaks, trufflehog, dockle, cyclonedx-cli, cosign, oras)"
 LABEL org.opencontainers.image.vendor="getbrik"
 LABEL org.opencontainers.image.licenses="MIT"
 
@@ -61,3 +64,14 @@ RUN chmod +x /tmp/install-scanner-tools.sh && /tmp/install-scanner-tools.sh \
     && trufflehog --version \
     && dockle --version \
     && (test -x /usr/local/bin/cyclonedx-cli && cyclonedx-cli --version || echo "cyclonedx-cli skipped (no upstream musl-arm64); jq fallback handles SBOM merge")
+
+# Evidence tools (cosign, oras): sign the published image digest and attach
+# SBOM + provenance as OCI referrers after the container scan.
+ENV COSIGN_VERSION=${COSIGN_VERSION} \
+    ORAS_VERSION=${ORAS_VERSION}
+
+COPY scripts/install-evidence-tools.sh /tmp/install-evidence-tools.sh
+RUN chmod +x /tmp/install-evidence-tools.sh && /tmp/install-evidence-tools.sh \
+    && rm -rf /tmp/* /var/cache/apk/* \
+    && cosign version \
+    && oras version

--- a/renovate.json
+++ b/renovate.json
@@ -177,6 +177,24 @@
       "depNameTemplate": "CycloneDX/cyclonedx-cli",
       "datasourceTemplate": "github-releases",
       "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "cosign version in versions.json",
+      "fileMatch": ["^versions\\.json$"],
+      "matchStrings": ["\"cosign\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "sigstore/cosign",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "oras version in versions.json",
+      "fileMatch": ["^versions\\.json$"],
+      "matchStrings": ["\"oras\":\\s*\"(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "oras-project/oras",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^v(?<version>.+)$"
     }
   ]
 }

--- a/scripts/generate-bake.sh
+++ b/scripts/generate-bake.sh
@@ -40,6 +40,13 @@ while IFS='=' read -r key value; do
     SECURITY_TOOLS["$key"]="$value"
 done < <(jq -r '.security_tools | to_entries[] | "\(.key)=\(.value)"' "$VERSIONS_FILE")
 
+# Read evidence_tools versions (cosign, oras): the scanner image signs the
+# image digest, the deploy image verifies the signature before deploying.
+declare -A EVIDENCE_TOOLS
+while IFS='=' read -r key value; do
+    EVIDENCE_TOOLS["$key"]="$value"
+done < <(jq -r '.evidence_tools | to_entries[] | "\(.key)=\(.value)"' "$VERSIONS_FILE")
+
 # Collect all target names for the default group
 ALL_TARGETS=()
 
@@ -100,6 +107,8 @@ XARGS
     TRUFFLEHOG_VERSION      = "${SECURITY_TOOLS[trufflehog]}"
     DOCKLE_VERSION          = "${SECURITY_TOOLS[dockle]}"
     CYCLONEDX_CLI_VERSION   = "${SECURITY_TOOLS[cyclonedx_cli]}"
+    COSIGN_VERSION          = "${EVIDENCE_TOOLS[cosign]}"
+    ORAS_VERSION            = "${EVIDENCE_TOOLS[oras]}"
 XARGS
 )
             elif [[ "$stack" == "deploy" ]]; then
@@ -107,6 +116,8 @@ XARGS
     HELM_VERSION            = "${DEPLOY_TOOLS[helm]}"
     KUBECTL_VERSION         = "${DEPLOY_TOOLS[kubectl]}"
     ARGOCD_VERSION          = "${DEPLOY_TOOLS[argocd]}"
+    COSIGN_VERSION          = "${EVIDENCE_TOOLS[cosign]}"
+    ORAS_VERSION            = "${EVIDENCE_TOOLS[oras]}"
 XARGS
 )
             fi

--- a/scripts/install-evidence-tools.sh
+++ b/scripts/install-evidence-tools.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# install-evidence-tools.sh - Install supply-chain evidence tools into an image.
+#
+# Installs: cosign, oras. Both are static Go binaries from GitHub releases,
+# multi-arch aware (amd64/arm64).
+#
+# Role in the CI/CD chain:
+#   - cosign signs the published image digest and attaches SBOM + SLSA
+#     provenance as signed OCI 1.1 referrers (CI flow), and verifies those
+#     attestations before a deploy (CD flow, fail-closed preflight).
+#   - oras reads and copies the referrer graph (discover at verify time;
+#     image + referrers copy at promotion).
+# The scanner image needs both to sign; the deploy image needs both to verify.
+
+set -euo pipefail
+
+# Tool versions arrive from the Docker build (ARG -> ENV) and originate in
+# versions.json (the single source of truth). Failing fast here surfaces a
+# missing wire-up in generate-bake.sh or the Dockerfile instead of silently
+# baking a stale binary.
+: "${COSIGN_VERSION:?COSIGN_VERSION must be set (passed from versions.json via Docker ARG)}"
+: "${ORAS_VERSION:?ORAS_VERSION must be set (passed from versions.json via Docker ARG)}"
+
+log() { printf '[install-evidence-tools] %s\n' "$*"; }
+
+detect_arch() {
+    local arch
+    arch="$(uname -m)"
+    case "$arch" in
+        x86_64)  echo "amd64" ;;
+        aarch64) echo "arm64" ;;
+        arm64)   echo "arm64" ;;
+        *)       echo "$arch" ;;
+    esac
+}
+
+ARCH="$(detect_arch)"
+
+install_cosign() {
+    log "installing cosign ${COSIGN_VERSION} (${ARCH})"
+    # cosign ships a bare binary per platform: cosign-linux-<arch>.
+    local url="https://github.com/sigstore/cosign/releases/download/v${COSIGN_VERSION}/cosign-linux-${ARCH}"
+    curl -sSL -o /usr/local/bin/cosign "$url"
+    chmod +x /usr/local/bin/cosign
+    cosign version
+}
+
+install_oras() {
+    log "installing oras ${ORAS_VERSION} (${ARCH})"
+    # oras ships a tarball: oras_<version>_linux_<arch>.tar.gz containing `oras`.
+    local url="https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_${ARCH}.tar.gz"
+    curl -sSL "$url" | tar xz -C /usr/local/bin oras
+    chmod +x /usr/local/bin/oras
+    oras version
+}
+
+main() {
+    log "starting evidence tools installation"
+    log "  ARCH=${ARCH}"
+
+    install_cosign
+    install_oras
+
+    log "all evidence tools installed successfully"
+}
+
+main "$@"

--- a/versions.json
+++ b/versions.json
@@ -12,6 +12,10 @@
     "kubectl": "v1.36.1",
     "argocd": "v3.4.2"
   },
+  "evidence_tools": {
+    "cosign": "3.0.6",
+    "oras": "1.3.2"
+  },
   "security_tools": {
     "semgrep": "1.163.0",
     "osv_scanner": "2.3.8",
@@ -66,12 +70,12 @@
     "scanner": {
       "versions": ["1"],
       "image_template": "alpine:3.23",
-      "verify_cmd": "grype version && syft version && osv-scanner --version && hadolint --version && gitleaks version && trufflehog --version && dockle --version"
+      "verify_cmd": "grype version && syft version && osv-scanner --version && hadolint --version && gitleaks version && trufflehog --version && dockle --version && cosign version && oras version"
     },
     "deploy": {
       "versions": ["1"],
       "image_template": "ghcr.io/getbrik/brik-runner-base:latest",
-      "verify_cmd": "helm version --short && kubectl version --client && argocd version --client"
+      "verify_cmd": "helm version --short && kubectl version --client && argocd version --client && cosign version && oras version"
     }
   }
 }


### PR DESCRIPTION
## Summary

Adds the supply-chain evidence toolchain to the runner images so the brik
CI/CD flow can sign and verify image attestations (P1-D prerequisite).

- **scanner** image gains `cosign` + `oras`: it signs the published image
  digest and attaches the SBOM + SLSA provenance as OCI 1.1 referrers after
  the container scan.
- **deploy** image gains `cosign` + `oras`: it verifies that signed
  attestation on the resolved digest before deploying (fail-closed CD
  preflight).

## Changes

- `versions.json`: new `evidence_tools` group (`cosign` 3.0.6, `oras` 1.3.2);
  `verify_cmd` updated for the scanner and deploy stacks.
- `scripts/install-evidence-tools.sh` (new): installs cosign (bare binary) and
  oras (tarball), multi-arch (amd64/arm64), shared by both images.
- `scripts/generate-bake.sh`: reads `evidence_tools` and wires
  `COSIGN_VERSION`/`ORAS_VERSION` into the scanner and deploy targets.
- `images/scanner/Dockerfile`, `images/deploy/Dockerfile`: ARGs, install step,
  and verify lines.
- `renovate.json`: version-bump rules for cosign and oras.

## Test plan

- [ ] CI builds the multi-arch scanner and deploy images
- [ ] Image `verify_cmd` passes (`cosign version && oras version` on both)
- [ ] hadolint passes on both Dockerfiles
- [ ] Grype gate green (add `.grype.yaml` GO-id suppressions if cosign/oras
      stdlib CVEs surface)