### PR TITLE
feat(images): add ssh-keygen to base and scanner runners

### DIFF
--- a/images/base/Dockerfile
+++ b/images/base/Dockerfile
@@ -37,7 +37,9 @@ LABEL org.opencontainers.image.description="Brik CI runner base image with bash,
 LABEL org.opencontainers.image.vendor="getbrik"
 LABEL org.opencontainers.image.licenses="MIT"
 
-RUN apk add --no-cache bash git curl ca-certificates
+# openssh-keygen ships ssh-keygen alone (no client/server): base verifies
+# ssh-signed evidence commits on the state repo (init/notify read-back).
+RUN apk add --no-cache bash git curl ca-certificates openssh-keygen
 
 # glow is not packaged in Alpine main/community (only edge/testing,
 # which is too volatile for a pinned base image). Install the upstream
@@ -72,4 +74,4 @@ COPY --from=jv-builder /jv /usr/local/bin/jv
 RUN echo "brik-runner" > /.brik-runner
 
 # Verify prerequisites
-RUN yq --version && jq --version && jv --version && git --version && bash --version && glow --version
+RUN yq --version && jq --version && jv --version && git --version && bash --version && glow --version && command -v ssh-keygen

--- a/images/scanner/Dockerfile
+++ b/images/scanner/Dockerfile
@@ -24,8 +24,9 @@ LABEL org.opencontainers.image.description="Brik CI runner with scanning tools (
 LABEL org.opencontainers.image.vendor="getbrik"
 LABEL org.opencontainers.image.licenses="MIT"
 
-# Base dependencies (no Python, no Ruby)
-RUN apk add --no-cache bash git curl ca-certificates \
+# Base dependencies (no Python, no Ruby). openssh-keygen ships ssh-keygen
+# alone: container-scan signs evidence commits on the state repo.
+RUN apk add --no-cache bash git curl ca-certificates openssh-keygen \
     && rm -rf /var/cache/apk/*
 
 # cyclonedx-cli (.NET self-contained on amd64) needs invariant globalization
@@ -55,7 +56,7 @@ COPY scripts/install-scanner-tools.sh /tmp/install-scanner-tools.sh
 RUN chmod +x /tmp/install-scanner-tools.sh && /tmp/install-scanner-tools.sh \
     && rm -rf /tmp/* /var/cache/apk/* \
     && echo "brik-runner-scanner" > /.brik-runner \
-    && yq --version && jq --version && git --version && bash --version \
+    && yq --version && jq --version && git --version && bash --version && command -v ssh-keygen \
     && grype version \
     && syft version \
     && osv-scanner --version \

--- a/versions.json
+++ b/versions.json
@@ -34,7 +34,7 @@
     "base": {
       "versions": ["3.23"],
       "image_template": "alpine:${VERSION}",
-      "verify_cmd": "bash --version"
+      "verify_cmd": "bash --version && command -v ssh-keygen"
     },
     "node": {
       "versions": ["22", "24"],
@@ -70,7 +70,7 @@
     "scanner": {
       "versions": ["1"],
       "image_template": "alpine:3.23",
-      "verify_cmd": "grype version && syft version && osv-scanner --version && hadolint --version && gitleaks version && trufflehog --version && dockle --version && cosign version && oras version"
+      "verify_cmd": "grype version && syft version && osv-scanner --version && hadolint --version && gitleaks version && trufflehog --version && dockle --version && cosign version && oras version && command -v ssh-keygen"
     },
     "deploy": {
       "versions": ["1"],


### PR DESCRIPTION
## Summary

Evidence commits on the CD state repo are ssh-signed: the scanner image signs them after container-scan, the base image verifies them at init and notify (read-back). Neither image shipped `ssh-keygen`, which git needs for ssh signing and verification.

- Add the Alpine `openssh-keygen` package to the **base** and **scanner** images: it ships `ssh-keygen` alone, without pulling the ssh client or server.
- Extend the Dockerfile build-time checks and the `versions.json` `verify_cmd` entries so smoke tests assert the tool is present.

`docker-bake.hcl` is unchanged: `verify_cmd` is consumed by the smoke tests only (regeneration verified, no drift).

Companion of the infrastructure-referential work on `brik` `feat/cicd-decoupling` (ssh-signed evidence via the `evidence-signing` credential); the briklab `node-deploy-signed` scenario needs these images rebuilt to go green.

## Test plan

- [x] `./scripts/generate-bake.sh` produces no diff
- [x] CI image builds green (hadolint + build matrix)
- [x] `./scripts/smoke-test.sh base 3.23` and `./scripts/smoke-test.sh scanner 1` pass with the new `command -v ssh-keygen` assertion
- [x] briklab E2E `node-deploy-signed` with `sign: true` once published