### PR TITLE
Treat the deploy image like every other image and clarify the README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -478,12 +478,114 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      - name: Scan with Grype
+        if: github.event_name != 'pull_request'
+        id: grype
+        uses: anchore/scan-action@e1165082ffb1fe366ebaf02d8526e7c4989ea9d2 # v7
+        with:
+          image: "${{ env.REGISTRY }}/brik-runner-${{ matrix.stack }}:${{ matrix.version }}"
+          fail-build: true
+          severity-cutoff: critical
+          only-fixed: true
+
+      - name: Upload Grype SARIF to GitHub Security
+        if: github.event_name != 'pull_request' && always()
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
+        with:
+          sarif_file: ${{ steps.grype.outputs.sarif }}
+          category: grype-${{ matrix.stack }}-${{ matrix.version }}
+
+      - name: Generate security badge data
+        if: github.event_name != 'pull_request' && always()
+        run: |
+          IMAGE="${REGISTRY}/brik-runner-${{ matrix.stack }}:${{ matrix.version }}"
+
+          # scan-action installs grype in hostedtoolcache but does not persist PATH
+          export PATH="/opt/hostedtoolcache/grype/$(ls /opt/hostedtoolcache/grype/ 2>/dev/null | head -1)/x64:${PATH}"
+
+          # Image is already in Docker daemon (pulled by scan-action)
+          # Full scan (not only-fixed) for transparency in badges
+          grype "docker:${IMAGE}" -o json > /tmp/grype-full.json 2>/tmp/grype-err.log || true
+          if [ -s /tmp/grype-err.log ]; then cat /tmp/grype-err.log; fi
+
+          if [ ! -s /tmp/grype-full.json ] || ! jq -e '.matches' /tmp/grype-full.json >/dev/null 2>&1; then
+            echo "::warning::Grype scan produced no valid results, using zero counts"
+            CRITICAL=0; HIGH=0; MEDIUM=0; LOW=0
+          else
+            CRITICAL=$(jq '[.matches[] | select(.vulnerability.severity == "Critical")] | length' /tmp/grype-full.json)
+            HIGH=$(jq '[.matches[] | select(.vulnerability.severity == "High")] | length' /tmp/grype-full.json)
+            MEDIUM=$(jq '[.matches[] | select(.vulnerability.severity == "Medium")] | length' /tmp/grype-full.json)
+            LOW=$(jq '[.matches[] | select(.vulnerability.severity == "Low")] | length' /tmp/grype-full.json)
+          fi
+
+          echo "CVE counts: Critical=$CRITICAL High=$HIGH Medium=$MEDIUM Low=$LOW"
+
+          if [ "$CRITICAL" -gt 0 ]; then COLOR="critical"
+          elif [ "$HIGH" -gt 0 ]; then COLOR="important"
+          elif [ "$MEDIUM" -gt 0 ]; then COLOR="yellow"
+          else COLOR="brightgreen"; fi
+
+          mkdir -p badges
+          jq -n --arg label "CVEs" \
+                --arg message "${CRITICAL}C | ${HIGH}H | ${MEDIUM}M | ${LOW}L" \
+                --arg color "$COLOR" \
+                '{schemaVersion:1, label:$label, message:$message, color:$color}' \
+            > "badges/${{ matrix.stack }}-${{ matrix.version }}.json"
+
+      - name: Upload badge data
+        if: github.event_name != 'pull_request' && always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: badge-${{ matrix.stack }}-${{ matrix.version }}
+          path: badges/
+
+      - name: Generate SBOM with Syft
+        if: github.event_name != 'pull_request'
+        uses: anchore/sbom-action@e22c389904149dbc22b58101806040fa8d37a610 # v0
+        with:
+          image: "${{ env.REGISTRY }}/brik-runner-${{ matrix.stack }}:${{ matrix.version }}"
+          format: cyclonedx-json
+          output-file: sbom-${{ matrix.stack }}-${{ matrix.version }}.json
+
+      - name: Upload SBOM
+        if: github.event_name != 'pull_request'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: sbom-${{ matrix.stack }}-${{ matrix.version }}
+          path: sbom-${{ matrix.stack }}-${{ matrix.version }}.json
+
       - name: Smoke test
         if: github.event_name == 'pull_request'
         run: |
           IMAGE="${REGISTRY}/brik-runner-${{ matrix.stack }}:${{ matrix.version }}"
           echo "Testing ${IMAGE}"
           docker run --rm "${IMAGE}" bash -c '${{ matrix.verify_cmd }}'
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Sign image
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          IMAGE="${REGISTRY}/brik-runner-${{ matrix.stack }}:${{ matrix.version }}"
+          cosign sign --yes "${IMAGE}"
+
+      - name: Attest SBOM
+        if: github.event_name != 'pull_request'
+        env:
+          COSIGN_EXPERIMENTAL: "true"
+        run: |
+          IMAGE="${REGISTRY}/brik-runner-${{ matrix.stack }}:${{ matrix.version }}"
+          # 409 Conflict is expected when the same attestation already exists in the transparency log
+          cosign attest --yes --predicate sbom-${{ matrix.stack }}-${{ matrix.version }}.json --type cyclonedx "${IMAGE}" || {
+            rc=$?
+            if [ $rc -ne 0 ]; then
+              echo "::warning::cosign attest exited with code $rc (409 conflict = attestation already exists, safe to ignore)"
+            fi
+          }
 
       - name: Attest build provenance
         if: github.event_name != 'pull_request'

--- a/README.md
+++ b/README.md
@@ -190,13 +190,13 @@ include:
     file: '/templates/brik-integrate.yml'
 ```
 
-Or override per-job:
+Or override the image on a single job. Here one job pins a newer Node than the `node:22` pipeline default set above:
 
 ```yaml
-build:
-  image: ghcr.io/getbrik/brik-runner-node:22  # or :22@sha256:... for digest pin
+e2e-tests:
+  image: ghcr.io/getbrik/brik-runner-node:24  # or :24@sha256:... for a digest pin
   script:
-    - brik stage build
+    - brik stage test
 ```
 
 ### Jenkins

--- a/README.md
+++ b/README.md
@@ -208,6 +208,15 @@ from `brik.yml`:
 brikIntegrate()
 ```
 
+### Local
+
+With the Brik CLI installed on your host, run the flow straight from your project directory. Brik drives the same containerized engine as CI, spawning one brik-runner container per stage (the image is resolved from your `brik.yml`):
+
+```bash
+brik integrate      # full CI flow locally, one container per stage
+brik stage build    # or run a single stage in its runner image
+```
+
 ### Using your own images (mirror, private registry, custom runners)
 
 Each runner class maps to an image in a runner-class map. To pull from a mirror, an
@@ -228,9 +237,7 @@ classes:
 Then set `BRIK_RUNNER_CLASSES_FILE=my-runner-classes.yml` for the pipeline.
 
 > [!NOTE]
-> GitHub Actions and zero-config local runs (`docker run ... brik ...`) are not supported
-> yet: Brik ships GitLab and Jenkins adapters today, and the runtime is cloned by those
-> adapters rather than baked into the image. See the [Roadmap](#roadmap).
+> Native pipeline templates exist for GitLab and Jenkins. The same containerized engine also runs on any host with Docker, including a CI runner with no native Brik adapter such as GitHub Actions: install the CLI and call `brik integrate`. The only thing still on the [Roadmap](#roadmap) is the zero-config form, `docker run <brik-runner-image> brik ...`, with Brik baked into the image so no host install is needed.
 
 ## Building locally
 
@@ -307,7 +314,7 @@ All tool and stack versions are defined in `versions.json` (single source of tru
 
 ## Roadmap
 
-The Brik runtime is currently cloned at CI time by the shared library's `before_script`, keeping image releases decoupled from Brik development. Once Brik reaches a stable release cadence, the runtime will be pre-installed in the images. That will unlock zero-config local usage (`docker run ghcr.io/getbrik/brik-runner-node:22 brik stage build`) and fully offline pipelines.
+The Brik runtime is currently cloned at run time (by the GitLab and Jenkins adapters, and by the local engine) rather than baked into the image, keeping image releases decoupled from Brik development. So today you run Brik with the CLI installed on your host (see [Local](#local)). Once Brik reaches a stable release cadence, the runtime will be pre-installed in the images, unlocking zero-config use with no host install (`docker run ghcr.io/getbrik/brik-runner-node:22 brik stage build`) and fully offline pipelines.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,20 @@ The scanning tooling is split into two images based on their runtime requirement
 | trufflehog | Secret scanning (entropy + patterns) |
 | dockle | Docker image best-practice linting |
 
-**Note**: the Brik runtime itself is NOT pre-installed. It is cloned at CI time by the shared library's `before_script`. This decouples image releases from Brik releases.
+> [!NOTE]
+> The Brik runtime itself is NOT pre-installed. It is cloned at CI time by the shared library's `before_script`. This decouples image releases from Brik releases.
+
+### Deploy image
+
+`brik-runner-deploy` (FROM base) carries the CD toolchain used by the deploy-class runner in Brik's CD flow. It adds cosign and oras on top of the deploy tools so the flow can verify the signed attestation on the resolved digest before deploying.
+
+| Tool | Purpose |
+|------|---------|
+| helm | Kubernetes package manager |
+| kubectl | Kubernetes CLI |
+| argocd | GitOps CD controller CLI |
+| cosign | Verify image signatures and attestations |
+| oras | OCI artifact transport (evidence) |
 
 ## Available images
 
@@ -101,6 +114,7 @@ The scanning tooling is split into two images based on their runtime requirement
 | `brik-runner-dotnet` | `10.0` | ![CVEs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/getbrik/brik-images/main/docs/badges/dotnet-10.0.json) | `docker pull ghcr.io/getbrik/brik-runner-dotnet:10.0` |
 | `brik-runner-analysis` | `1` | ![CVEs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/getbrik/brik-images/main/docs/badges/analysis-1.json) | `docker pull ghcr.io/getbrik/brik-runner-analysis` |
 | `brik-runner-scanner` | `1` | ![CVEs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/getbrik/brik-images/main/docs/badges/scanner-1.json) | `docker pull ghcr.io/getbrik/brik-runner-scanner` |
+| `brik-runner-deploy` | `1` | ![CVEs](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/getbrik/brik-images/main/docs/badges/deploy-1.json) | `docker pull ghcr.io/getbrik/brik-runner-deploy` |
 
 All images are multi-arch: `linux/amd64` and `linux/arm64`.
 
@@ -116,15 +130,17 @@ Every image is scanned, signed, and continuously rebuilt:
 
 ### Current CVE posture
 
-**These images are not CVE-free.** They bundle the latest upstream base images (`node:*-slim`, `python:*-slim`, Debian, Alpine), and those carry vulnerabilities their maintainers have not patched yet. Several stack images currently show **Critical** CVEs, and every non-base image shows dozens of **High** -- the per-image badge in the [Available images](#available-images) table is the live count, and the [Security tab](https://github.com/getbrik/brik-images/security/code-scanning) the per-CVE detail. Treat those, not this prose, as the source of truth.
+> [!IMPORTANT]
+> **These images are not CVE-free.** They bundle the latest upstream base images (`node:*-slim`, `python:*-slim`, Debian, Alpine), and those carry vulnerabilities their maintainers have not patched yet. Several stack images currently show **Critical** CVEs, and every non-base image shows dozens of **High** -- the per-image badge in the [Available images](#available-images) table is the live count, and the [Security tab](https://github.com/getbrik/brik-images/security/code-scanning) the per-CVE detail. Treat those, not this prose, as the source of truth.
 
 **What we control:** the bundled tools (`yq`, `jq`, `git`, and the scanner/analysis binaries) are pinned to current releases and bumped regularly; the build blocks on a Critical that has a fix.
 
 **What we don't control:** CVEs in the language runtimes themselves and in statically-linked Go binaries -- those clear only when the runtime or tool upstream ships a patched release. For production use, pin images by digest and run a scan gate against your own risk policy.
 
-### Suppressed CVEs (read this)
+### Suppressed CVEs
 
-A few CVEs are suppressed in [`.grype.yaml`](.grype.yaml) so the build can stay green: Go-toolchain vulnerabilities compiled into statically-linked scanner binaries (`dockle`, `gitleaks`, `osv-scanner`) that we cannot remediate without forking the upstream project. [`.grype.yaml`](.grype.yaml) is the canonical list.
+> [!IMPORTANT]
+> A few CVEs are suppressed in [`.grype.yaml`](.grype.yaml) so the build can stay green: Go-toolchain vulnerabilities compiled into statically-linked scanner binaries (`dockle`, `gitleaks`, `osv-scanner`) that we cannot remediate without forking the upstream project. [`.grype.yaml`](.grype.yaml) is the canonical list.
 
 The **live status** -- the per-tool breakdown, and whether a patched upstream release is available yet -- is the auto-refreshed [CVE Suppression Review issue](https://github.com/getbrik/brik-images/issues?q=is%3Aissue+label%3Acve-suppression-review), regenerated every Monday by [`scripts/review-cve-suppressions.sh`](scripts/review-cve-suppressions.sh). When a tool ships a release on a patched Go, bump it in [`versions.json`](versions.json) and drop its entry from `.grype.yaml` and [`.cve-suppressions.json`](.cve-suppressions.json).
 
@@ -155,7 +171,8 @@ ghcr.io/getbrik/brik-runner-node:sha-a1b2c3d      # immutable git SHA
 ghcr.io/getbrik/brik-runner-node:22@sha256:...    # digest pin (most secure)
 ```
 
-**For production pipelines**, pin images by digest (`@sha256:...`) to guarantee reproducible builds. Mutable tags like `:22` or `:latest` can change on rebuilds. Use `docker inspect --format='{{index .RepoDigests 0}}' <image>` to retrieve the current digest.
+> [!IMPORTANT]
+> **For production pipelines**, pin images by digest (`@sha256:...`) to guarantee reproducible builds. Mutable tags like `:22` or `:latest` can change on rebuilds. Use `docker inspect --format='{{index .RepoDigests 0}}' <image>` to retrieve the current digest.
 
 ## Usage
 
@@ -169,8 +186,8 @@ variables:
 
 include:
   - project: 'brik/gitlab-templates'
-    ref: v1
-    file: '/templates/pipeline.yml'
+    ref: v0.7.0
+    file: '/templates/brik-integrate.yml'
 ```
 
 Or override per-job:
@@ -179,7 +196,7 @@ Or override per-job:
 build:
   image: ghcr.io/getbrik/brik-runner-node:22  # or :22@sha256:... for digest pin
   script:
-    - brik run stage build
+    - brik stage build
 ```
 
 ### Jenkins
@@ -196,7 +213,7 @@ pipeline {
     stages {
         stage('Build') {
             steps {
-                sh 'brik run stage build'
+                sh 'brik stage build'
             }
         }
     }
@@ -215,7 +232,7 @@ jobs:
       image: ghcr.io/getbrik/brik-runner-node:22
     steps:
       - uses: actions/checkout@v4
-      - run: brik run stage build
+      - run: brik stage build
 ```
 
 ### Local development
@@ -223,7 +240,7 @@ jobs:
 ```bash
 docker run --rm -v "$(pwd):/workspace" -w /workspace \
   ghcr.io/getbrik/brik-runner-node:22 \
-  brik run stage build
+  brik stage build
 ```
 
 ## Building locally
@@ -301,7 +318,7 @@ All tool and stack versions are defined in `versions.json` (single source of tru
 
 ## Roadmap
 
-The Brik runtime is currently cloned at CI time by the shared library's `before_script`, keeping image releases decoupled from Brik development. Once Brik reaches a stable release cadence, the runtime will be pre-installed in the images. That will unlock zero-config local usage (`docker run ghcr.io/getbrik/brik-runner-node:22 brik run stage build`) and fully offline pipelines.
+The Brik runtime is currently cloned at CI time by the shared library's `before_script`, keeping image releases decoupled from Brik development. Once Brik reaches a stable release cadence, the runtime will be pre-installed in the images. That will unlock zero-config local usage (`docker run ghcr.io/getbrik/brik-runner-node:22 brik stage build`) and fully offline pipelines.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Stock language images (`node:24-slim`, `python:3.13-slim`) are great for develop
 - Every CI job re-installs the same `bash 5+`, `yq`, `jq`, `git`, `curl`. 30 to 40 seconds, every job, every pipeline.
 - No signature, no attestation, no SBOM. You take the maintainer's word for what is inside.
 - CVE patches lag. Stock images rebuild on the maintainer's cadence, not yours.
-- No CI-specific tooling. SAST, SCA, secret scanning, container linting -- you bring your own and install per job.
+- No CI-specific tooling. SAST, SCA, secret scanning, container linting: you bring your own and install per job.
 
 brik-images are CI runner images. Bootstrap is gone. Provenance is signed. CVE posture is published live, per image, on every push. Scanner and analysis tools come pre-installed in dedicated images.
 
@@ -48,10 +48,10 @@ Every build applies the base image's pending OS security updates (`apt-get upgra
 Every image contains:
 
 - **bash** (5.x)
-- **yq** -- YAML processor
-- **jq** -- JSON processor
-- **git** -- version control
-- **curl** -- HTTP client
+- **yq**: YAML processor
+- **jq**: JSON processor
+- **git**: version control
+- **curl**: HTTP client
 
 Stack images additionally include their respective toolchain (node/npm, python/pip, java/maven, rust/cargo, dotnet/sdk). Exact pinned versions of every bundled tool are in [`versions.json`](versions.json).
 
@@ -59,8 +59,8 @@ Stack images additionally include their respective toolchain (node/npm, python/p
 
 The scanning tooling is split into two images based on their runtime requirements:
 
-- **analysis** -- Python/Ruby runtime, for deep SAST analysis, license compliance, and IaC scanning.
-- **scanner** -- static Go binaries only, fast to pull, for vulnerability scanning, secret detection, Dockerfile linting, and container scanning.
+- **analysis**: Python/Ruby runtime, for deep SAST analysis, license compliance, and IaC scanning.
+- **scanner**: static Go binaries only, fast to pull, for vulnerability scanning, secret detection, Dockerfile linting, and container scanning.
 
 #### Analysis image (~1.7 GB)
 
@@ -122,7 +122,7 @@ All images are multi-arch: `linux/amd64` and `linux/arm64`.
 
 Every image is scanned, signed, and continuously rebuilt:
 
-- ✅ Scanned with [Grype](https://github.com/anchore/grype) on every build. The build **hard-fails only on a Critical CVE that has an available upstream fix** -- Critical and High CVEs that upstream has not patched yet are recorded, not blocked.
+- ✅ Scanned with [Grype](https://github.com/anchore/grype) on every build. The build **hard-fails only on a Critical CVE that has an available upstream fix**. Critical and High CVEs that upstream has not patched yet are recorded, not blocked.
 - ✅ Scan results uploaded to the [Security tab](https://github.com/getbrik/brik-images/security/code-scanning) for full per-image visibility.
 - ✅ SBOMs generated with [Syft](https://github.com/anchore/syft) in CycloneDX format.
 - ✅ Images signed with [cosign](https://github.com/sigstore/cosign) (keyless, OIDC).
@@ -131,18 +131,18 @@ Every image is scanned, signed, and continuously rebuilt:
 ### Current CVE posture
 
 > [!IMPORTANT]
-> **These images are not CVE-free.** They bundle the latest upstream base images (`node:*-slim`, `python:*-slim`, Debian, Alpine), and those carry vulnerabilities their maintainers have not patched yet. Several stack images currently show **Critical** CVEs, and every non-base image shows dozens of **High** -- the per-image badge in the [Available images](#available-images) table is the live count, and the [Security tab](https://github.com/getbrik/brik-images/security/code-scanning) the per-CVE detail. Treat those, not this prose, as the source of truth.
+> **These images are not CVE-free.** They bundle the latest upstream base images (`node:*-slim`, `python:*-slim`, Debian, Alpine), and those carry vulnerabilities their maintainers have not patched yet. Several stack images currently show **Critical** CVEs, and every non-base image shows dozens of **High**. The per-image badge in the [Available images](#available-images) table is the live count, and the [Security tab](https://github.com/getbrik/brik-images/security/code-scanning) the per-CVE detail. Treat those, not this prose, as the source of truth.
 
 **What we control:** the bundled tools (`yq`, `jq`, `git`, and the scanner/analysis binaries) are pinned to current releases and bumped regularly; the build blocks on a Critical that has a fix.
 
-**What we don't control:** CVEs in the language runtimes themselves and in statically-linked Go binaries -- those clear only when the runtime or tool upstream ships a patched release. For production use, pin images by digest and run a scan gate against your own risk policy.
+**What we don't control:** CVEs in the language runtimes themselves and in statically-linked Go binaries; those clear only when the runtime or tool upstream ships a patched release. For production use, pin images by digest and run a scan gate against your own risk policy.
 
 ### Suppressed CVEs
 
 > [!IMPORTANT]
 > A few CVEs are suppressed in [`.grype.yaml`](.grype.yaml) so the build can stay green: Go-toolchain vulnerabilities compiled into statically-linked scanner binaries (`dockle`, `gitleaks`, `osv-scanner`) that we cannot remediate without forking the upstream project. [`.grype.yaml`](.grype.yaml) is the canonical list.
 
-The **live status** -- the per-tool breakdown, and whether a patched upstream release is available yet -- is the auto-refreshed [CVE Suppression Review issue](https://github.com/getbrik/brik-images/issues?q=is%3Aissue+label%3Acve-suppression-review), regenerated every Monday by [`scripts/review-cve-suppressions.sh`](scripts/review-cve-suppressions.sh). When a tool ships a release on a patched Go, bump it in [`versions.json`](versions.json) and drop its entry from `.grype.yaml` and [`.cve-suppressions.json`](.cve-suppressions.json).
+The **live status** (the per-tool breakdown, and whether a patched upstream release is available yet) is the auto-refreshed [CVE Suppression Review issue](https://github.com/getbrik/brik-images/issues?q=is%3Aissue+label%3Acve-suppression-review), regenerated every Monday by [`scripts/review-cve-suppressions.sh`](scripts/review-cve-suppressions.sh). When a tool ships a release on a patched Go, bump it in [`versions.json`](versions.json) and drop its entry from `.grype.yaml` and [`.cve-suppressions.json`](.cve-suppressions.json).
 
 ### Verifying
 
@@ -314,7 +314,7 @@ All tool and stack versions are defined in `versions.json` (single source of tru
 
 1. Edit `versions.json`
 2. Run `./scripts/generate-bake.sh` (or use `--regenerate` with `build-local.sh`)
-3. Commit and push -- CI handles the rest
+3. Commit and push; CI handles the rest
 
 ## Roadmap
 

--- a/README.md
+++ b/README.md
@@ -190,11 +190,11 @@ include:
     file: '/templates/brik-integrate.yml'
 ```
 
-Or override the image on a single job. Here one job pins a newer Node than the `node:22` pipeline default set above:
+Or override the image on a single job. Here one job uses a custom image from your own registry (for example a brik runner extended with in-house tooling), instead of the public `node:22` pipeline default set above:
 
 ```yaml
 e2e-tests:
-  image: ghcr.io/getbrik/brik-runner-node:24  # or :24@sha256:... for a digest pin
+  image: registry.example.com/acme/brik-runner-node-e2e:1.4.0  # built FROM ghcr.io/getbrik/brik-runner-node, plus your test tooling
   script:
     - brik stage test
 ```

--- a/README.md
+++ b/README.md
@@ -176,72 +176,61 @@ ghcr.io/getbrik/brik-runner-node:22@sha256:...    # digest pin (most secure)
 
 ## Usage
 
+You do not pick the image by hand, and you do not install `brik` into it. The `init` job
+reads `project.stack` and `project.stack_version` from your `brik.yml` and resolves each
+stage to the matching `ghcr.io/getbrik/brik-runner-<stack>:<version>`; the shared library
+clones the Brik runtime into the container at job start.
+
 ### GitLab CI
+
+Include the Brik template. That is the whole pipeline:
 
 ```yaml
 # .gitlab-ci.yml
-variables:
-  # Pin by digest for reproducible builds: ghcr.io/getbrik/brik-runner-node:22@sha256:...
-  BRIK_CI_IMAGE: "ghcr.io/getbrik/brik-runner-node:22"
-
 include:
   - project: 'brik/gitlab-templates'
     ref: v0.7.0
     file: '/templates/brik-integrate.yml'
 ```
 
-Or override the image on a single job. Here one job uses a custom image from your own registry (for example a brik runner extended with in-house tooling), instead of the public `node:22` pipeline default set above:
-
-```yaml
-e2e-tests:
-  image: registry.example.com/acme/brik-runner-node-e2e:1.4.0  # built FROM ghcr.io/getbrik/brik-runner-node, plus your test tooling
-  script:
-    - brik stage test
-```
+With `project.stack: node` and `stack_version: "22"` in `brik.yml`, the stage jobs run on
+`ghcr.io/getbrik/brik-runner-node:22`; the scan, analysis and deploy stages run on their
+dedicated images automatically.
 
 ### Jenkins
 
+Load the Brik shared library and call the orchestrator. Same automatic image resolution
+from `brik.yml`:
+
 ```groovy
-pipeline {
-    agent {
-        docker {
-            // Pin by digest for reproducible builds:
-            // image 'ghcr.io/getbrik/brik-runner-java:21@sha256:...'
-            image 'ghcr.io/getbrik/brik-runner-java:21'
-        }
-    }
-    stages {
-        stage('Build') {
-            steps {
-                sh 'brik stage build'
-            }
-        }
-    }
-}
+// Jenkinsfile
+@Library('brik') _
+brikIntegrate()
 ```
 
-### GitHub Actions
+### Using your own images (mirror, private registry, custom runners)
+
+Each runner class maps to an image in a runner-class map. To pull from a mirror, an
+air-gapped registry, or your own runners extended with in-house tooling, point Brik at an
+alternate map with the `BRIK_RUNNER_CLASSES_FILE` pipeline variable (a CI variable on
+GitLab, a build parameter on Jenkins) instead of editing your CI file:
 
 ```yaml
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    container:
-      # Pin by digest for reproducible builds:
-      # image: ghcr.io/getbrik/brik-runner-node:22@sha256:...
-      image: ghcr.io/getbrik/brik-runner-node:22
-    steps:
-      - uses: actions/checkout@v4
-      - run: brik stage build
+# my-runner-classes.yml, committed in your repo
+classes:
+  base:     { image: registry.example.com/acme/brik-runner-base,     tag: "1.4.0" }
+  scanner:  { image: registry.example.com/acme/brik-runner-scanner,  tag: "1.4.0" }
+  analysis: { image: registry.example.com/acme/brik-runner-analysis, tag: "1.4.0" }
+  deploy:   { image: registry.example.com/acme/brik-runner-deploy,   tag: "1.4.0" }
+  stack:    { image_env: BRIK_CI_IMAGE }   # stack image stays resolved from brik.yml
 ```
 
-### Local development
+Then set `BRIK_RUNNER_CLASSES_FILE=my-runner-classes.yml` for the pipeline.
 
-```bash
-docker run --rm -v "$(pwd):/workspace" -w /workspace \
-  ghcr.io/getbrik/brik-runner-node:22 \
-  brik stage build
-```
+> [!NOTE]
+> GitHub Actions and zero-config local runs (`docker run ... brik ...`) are not supported
+> yet: Brik ships GitLab and Jenkins adapters today, and the runtime is cloned by those
+> adapters rather than baked into the image. See the [Roadmap](#roadmap).
 
 ## Building locally
 


### PR DESCRIPTION
## CI (build.yml)

The `deploy` image (built in `build-dependent` because it is FROM base) only built and attested provenance. It now runs the **same steps as every other image**: Grype scan (hard-fail on a Critical-with-fix), SARIF upload to the Security tab, CVE badge generation, SBOM with Syft, cosign signing, and SBOM attestation. So `brik-runner-deploy` becomes a first-class, scanned/signed/badged image and the README's "every image is signed and scanned" claims hold for it too.

> Note: the `deploy-1.json` badge populates on the next `main` build (badges are generated, not hand-written), so the new table badge is briefly a 404 until then.

## README

- **Factual fixes**: the local-run command is `brik stage build` (there is no `brik run` verb in `bin/brik`); the GitLab include is `ref: v0.7.0` + `file: '/templates/brik-integrate.yml'` (was `v1` / `pipeline.yml`).
- **deploy image documented**: a row in Available images plus a short section listing its toolchain (helm/kubectl/argocd/cosign/oras).
- **GitHub alerts** for the strong callouts (runtime not pre-installed, CVEs are not zero, suppressed CVEs, pin by digest in production).

Generated badge files under `docs/badges/` and the shields.io endpoint URLs are untouched.