### PR TITLE
chore: bump the Alpine base from 3.23 to 3.24

### DIFF
--- a/images/analysis/Dockerfile
+++ b/images/analysis/Dockerfile
@@ -42,7 +42,7 @@ RUN mkdir -p /installed-bin \
 # Stage the Python site-packages at a fixed, version-agnostic path. The Alpine
 # Python minor version moves with the base image (3.12 on Alpine 3.23, 3.14 on
 # 3.24), so the final stage must not hardcode it.
-RUN cp -a "$(ls -d /usr/lib/python3.*/site-packages | head -1)" /opt/py-site-packages
+RUN cp -a /usr/lib/python3.*/site-packages /opt/py-site-packages
 
 # ---------------------------------------------------------------------------
 # Stage 2: final - runtime only (no dev deps, no build-base)

--- a/images/analysis/Dockerfile
+++ b/images/analysis/Dockerfile
@@ -5,7 +5,7 @@ ARG VERSION
 # ---------------------------------------------------------------------------
 # Stage 1: builder - install Python/Ruby tools with dev dependencies
 # ---------------------------------------------------------------------------
-FROM alpine:3.23 AS builder
+FROM alpine:3.24 AS builder
 
 RUN apk add --no-cache \
     bash \
@@ -42,7 +42,7 @@ RUN mkdir -p /installed-bin \
 # ---------------------------------------------------------------------------
 # Stage 2: final - runtime only (no dev deps, no build-base)
 # ---------------------------------------------------------------------------
-FROM alpine:3.23
+FROM alpine:3.24
 
 ARG VERSION
 ARG YQ_VERSION

--- a/images/analysis/Dockerfile
+++ b/images/analysis/Dockerfile
@@ -39,6 +39,11 @@ RUN mkdir -p /installed-bin \
          cp "/usr/bin/$f" /installed-bin/; \
        done
 
+# Stage the Python site-packages at a fixed, version-agnostic path. The Alpine
+# Python minor version moves with the base image (3.12 on Alpine 3.23, 3.14 on
+# 3.24), so the final stage must not hardcode it.
+RUN cp -a "$(ls -d /usr/lib/python3.*/site-packages | head -1)" /opt/py-site-packages
+
 # ---------------------------------------------------------------------------
 # Stage 2: final - runtime only (no dev deps, no build-base)
 # ---------------------------------------------------------------------------
@@ -81,8 +86,10 @@ ENV YQ_VERSION=${YQ_VERSION} \
 COPY scripts/install-brik-prereqs.sh /tmp/install-brik-prereqs.sh
 RUN chmod +x /tmp/install-brik-prereqs.sh && /tmp/install-brik-prereqs.sh && rm /tmp/install-brik-prereqs.sh
 
-# Copy Python site-packages from builder
-COPY --from=builder /usr/lib/python3.12/site-packages /usr/lib/python3.12/site-packages
+# Python site-packages from the builder, staged at a fixed path and exposed via
+# PYTHONPATH so this stays correct across Alpine Python version bumps.
+COPY --from=builder /opt/py-site-packages /opt/py-site-packages
+ENV PYTHONPATH=/opt/py-site-packages
 # Copy all pip/gem entry-point scripts added during install
 COPY --from=builder /installed-bin/ /usr/bin/
 

--- a/images/scanner/Dockerfile
+++ b/images/scanner/Dockerfile
@@ -2,7 +2,7 @@
 # Contains: grype, syft, osv-scanner, hadolint, gitleaks, trufflehog, dockle,
 #           cyclonedx-cli, cosign, oras
 ARG VERSION
-FROM alpine:3.23
+FROM alpine:3.24
 
 ARG YQ_VERSION
 ARG JQ_VERSION

--- a/versions.json
+++ b/versions.json
@@ -32,7 +32,7 @@
   },
   "stacks": {
     "base": {
-      "versions": ["3.23"],
+      "versions": ["3.24"],
       "image_template": "alpine:${VERSION}",
       "verify_cmd": "bash --version && command -v ssh-keygen"
     },
@@ -64,12 +64,12 @@
     },
     "analysis": {
       "versions": ["1"],
-      "image_template": "alpine:3.23",
+      "image_template": "alpine:3.24",
       "verify_cmd": "semgrep --version && checkov --version && license_finder version && scancode --version"
     },
     "scanner": {
       "versions": ["1"],
-      "image_template": "alpine:3.23",
+      "image_template": "alpine:3.24",
       "verify_cmd": "grype version && syft version && osv-scanner --version && hadolint --version && gitleaks version && trufflehog --version && dockle --version && cosign version && oras version && command -v ssh-keygen"
     },
     "deploy": {


### PR DESCRIPTION
Bumps the base, analysis and scanner images to Alpine 3.24.

**Why:** the deploy image (FROM `brik-runner-base`) installs `docker-cli-compose` from Alpine. On 3.23 that is compose 2.40.3, whose statically-linked `google.golang.org/grpc` v1.74.2 carries a Critical (CVE-2026-33186 / GHSA-p77j-4mvh-x3m3 / GO-2026-4762) that the deploy scan gate hard-fails on. Alpine 3.24 ships compose 5.1.4, which clears it (verified: a scan of `alpine:3.24` + `docker-cli-compose` shows no grpc CVE). So no `.grype.yaml` suppression is needed for grpc.

**Scope:** `versions.json` base version + analysis/scanner `image_template`, and the hardcoded `FROM alpine:3.23` in the analysis/scanner Dockerfiles. `docker-bake.hcl` is gitignored (CI reads `versions.json` directly).

**Validation:** needs the post-merge `main` rebuild+scan to confirm deploy goes green and no new Critical appears on scanner/analysis on 3.24.