### PR TITLE
chore: bump pinned tool versions to current stable releases

### DIFF
--- a/versions.json
+++ b/versions.json
@@ -8,25 +8,25 @@
     "glow": "v2.1.2"
   },
   "deploy_tools": {
-    "helm": "v4.2.0",
-    "kubectl": "v1.36.1",
-    "argocd": "v3.4.2"
+    "helm": "v4.2.1",
+    "kubectl": "v1.36.2",
+    "argocd": "v3.4.3"
   },
   "evidence_tools": {
-    "cosign": "3.0.6",
+    "cosign": "3.1.1",
     "oras": "1.3.2"
   },
   "security_tools": {
-    "semgrep": "1.163.0",
+    "semgrep": "1.166.0",
     "osv_scanner": "2.3.8",
-    "grype": "0.112.0",
-    "syft": "1.44.0",
-    "checkov": "3.2.529",
+    "grype": "0.114.0",
+    "syft": "1.45.1",
+    "checkov": "3.3.1",
     "hadolint": "2.14.0",
     "license_finder": "7.2.1",
     "scancode_toolkit": "32.5.0",
     "gitleaks": "8.30.1",
-    "trufflehog": "3.95.3",
+    "trufflehog": "3.95.5",
     "dockle": "0.4.15",
     "cyclonedx_cli": "0.32.0"
   },


### PR DESCRIPTION
Refreshes the pinned tool versions in `versions.json` to their latest stable upstream releases:

| Tool | From | To |
|------|------|----|
| helm | v4.2.0 | v4.2.1 |
| kubectl | v1.36.1 | v1.36.2 |
| argocd | v3.4.2 | v3.4.3 |
| cosign | 3.0.6 | 3.1.1 |
| semgrep | 1.163.0 | 1.166.0 |
| checkov | 3.2.529 | 3.3.1 |
| grype | 0.112.0 | 0.114.0 |
| syft | 1.44.0 | 1.45.1 |
| trufflehog | 3.95.3 | 3.95.5 |

**Notes:**
- grype/syft bumps clear their own x/crypto findings but do NOT let us drop the shared `.grype.yaml` entries (still triggered by docker-buildx / osv-scanner / gitleaks, which have no fixed release yet).
- `jv` is intentionally left at `v0.7.0`: that is the latest `cmd/jv` tag (a separate Go module from the `jsonschema/v6` library; the `v6.0.2` release is the library, not the CLI), and it already bundles jsonschema v6 with draft 2020-12 support.
- Other tools (yq, jq, glow, oras, osv-scanner, hadolint, license_finder, scancode, gitleaks, dockle, cyclonedx-cli, docker-buildx) are already at their latest stable.